### PR TITLE
feat: add interview qa generator

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,124 +21,148 @@ def create_streamlit_app(llm: Chain, clean_text_fn):
 
     col1, col2 = st.columns(2)
     with col1:
-        generate_cover_letter = st.button("Generate Cover Letter")
-    with col2:
-        generate_qa = st.button("Generate Interview Q&A")
-
-    if generate_cover_letter or generate_qa:
-        if not resume_file or not job_input:
-            st.error("Please provide both a resume and a job description or URL.")
-            return
-
-        try:
-            pdf_reader = PdfReader(resume_file)
-            resume_text = "".join(page.extract_text() or "" for page in pdf_reader.pages)
-            resume_text = clean_text_fn(resume_text)
-            resume_info = extract_structured_info(resume_text)
-            job_description = load_job_description(job_input)
-
-            if generate_cover_letter:
-                job_skills = extract_job_skills(job_description)
-                skill_map = map_skills(resume_info["skills"], job_skills)
-                score, breakdown = compute_skill_match_score(resume_text, job_skills)
-                concise_letter = llm.write_cover_letter(
-                    resume_info, job_description, style="concise"
-                )
-                detailed_letter = llm.write_cover_letter(
-                    resume_info, job_description, style="detailed"
-                )
-
-                if "concise_text" not in st.session_state:
-                    st.session_state.concise_text = concise_letter
-                if "detailed_text" not in st.session_state:
-                    st.session_state.detailed_text = detailed_letter
-
-                st.subheader("Cover Letter Versions")
-                col_a, col_b = st.columns(2)
-                with col_a:
-                    st.subheader("Concise")
-                    st.text_area(
-                        "Concise Cover Letter",
-                        key="concise_text",
-                        height=300,
-                    )
-                with col_b:
-                    st.subheader("Detailed")
-                    st.text_area(
-                        "Detailed Cover Letter",
-                        key="detailed_text",
-                        height=300,
-                    )
-
-                st.subheader("Refine Cover Letter")
-                version_to_refine = st.selectbox(
-                    "Version to refine", ["Concise", "Detailed"], key="version_select"
-                )
-                tone = st.selectbox(
-                    "Tone",
-                    ["Default", "Formal", "Friendly", "Confident"],
-                    key="tone_select",
-                )
-                instructions = st.text_input(
-                    "Additional instructions (optional)", key="refine_instruction"
-                )
-                if st.button("Apply Refinement"):
-                    refine_instructions = (
-                        f"Rewrite in a {tone.lower()} tone. " if tone != "Default" else ""
-                    )
-                    refine_instructions += instructions
-                    target_key = (
-                        "concise_text" if version_to_refine == "Concise" else "detailed_text"
-                    )
-                    if refine_instructions.strip():
-                        st.session_state[target_key] = llm.refine_cover_letter(
-                            st.session_state[target_key], refine_instructions
-                        )
-                    else:
-                        st.warning(
-                            "Please provide refinement instructions or select a tone."
-                        )
-
-                final_choice = st.radio(
-                    "Select final version", ["Concise", "Detailed"], key="final_choice"
-                )
-                if st.button("Finalize Cover Letter"):
-                    final_letter = (
-                        st.session_state.concise_text
-                        if final_choice == "Concise"
-                        else st.session_state.detailed_text
-                    )
-                    st.subheader("Final Cover Letter")
-                    st.code(final_letter, language="markdown")
-
-                st.subheader("Skill Match Analysis")
-                st.metric("Overall Score", f"{score * 100:.1f}%")
-                if breakdown:
-                    chart_df = pd.DataFrame(
-                        {
-                            "Skill": list(breakdown.keys()),
-                            "Relevance": [v * 100 for v in breakdown.values()],
-                        }
-                    ).set_index("Skill")
-                    st.bar_chart(chart_df)
-
-                if skill_map["matched"]:
-                    st.info("Matched skills: " + ", ".join(skill_map["matched"]))
-                if skill_map["gaps"]:
-                    st.warning("Skill gaps: " + ", ".join(skill_map["gaps"]))
-
+        if st.button("Generate Cover Letter"):
+            if not resume_file or not job_input:
+                st.error("Please provide both a resume and a job description or URL.")
             else:
-                qa_pairs = llm.generate_interview_qa(resume_info, job_description)
-                st.code(qa_pairs, language="markdown")
+                try:
+                    pdf_reader = PdfReader(resume_file)
+                    resume_text = "".join(
+                        page.extract_text() or "" for page in pdf_reader.pages
+                    )
+                    resume_text = clean_text_fn(resume_text)
+                    resume_info = extract_structured_info(resume_text)
+                    job_description = load_job_description(job_input)
 
-        except Exception as e:
-            st.error(f"An Error Occurred: {e}")
+                    job_skills = extract_job_skills(job_description)
+                    skill_map = map_skills(resume_info["skills"], job_skills)
+                    score, breakdown = compute_skill_match_score(
+                        resume_text, job_skills
+                    )
+                    concise_letter = llm.write_cover_letter(
+                        resume_info, job_description, style="concise"
+                    )
+                    detailed_letter = llm.write_cover_letter(
+                        resume_info, job_description, style="detailed"
+                    )
+
+                    st.session_state.update(
+                        {
+                            "concise_text": concise_letter,
+                            "detailed_text": detailed_letter,
+                            "skill_map": skill_map,
+                            "score": score,
+                            "breakdown": breakdown,
+                            "cover_letter_generated": True,
+                        }
+                    )
+                except Exception as e:
+                    st.error(f"An Error Occurred: {e}")
+
+    with col2:
+        if st.button("Generate Interview Q&A"):
+            if not resume_file or not job_input:
+                st.error("Please provide both a resume and a job description or URL.")
+            else:
+                try:
+                    pdf_reader = PdfReader(resume_file)
+                    resume_text = "".join(
+                        page.extract_text() or "" for page in pdf_reader.pages
+                    )
+                    resume_text = clean_text_fn(resume_text)
+                    resume_info = extract_structured_info(resume_text)
+                    job_description = load_job_description(job_input)
+                    qa_pairs = llm.generate_interview_qa(resume_info, job_description)
+                    st.session_state.update(
+                        {"qa_pairs": qa_pairs, "qa_generated": True}
+                    )
+                except Exception as e:
+                    st.error(f"An Error Occurred: {e}")
+
+    if st.session_state.get("cover_letter_generated"):
+        st.subheader("Cover Letter Versions")
+        col_a, col_b = st.columns(2)
+        with col_a:
+            st.subheader("Concise")
+            st.text_area("Concise Cover Letter", key="concise_text", height=300)
+        with col_b:
+            st.subheader("Detailed")
+            st.text_area("Detailed Cover Letter", key="detailed_text", height=300)
+
+        st.subheader("Refine Cover Letter")
+        version_to_refine = st.selectbox(
+            "Version to refine", ["Concise", "Detailed"], key="version_select"
+        )
+        tone = st.selectbox(
+            "Tone", ["Default", "Formal", "Friendly", "Confident"], key="tone_select"
+        )
+        instructions = st.text_input(
+            "Additional instructions (optional)", key="refine_instruction"
+        )
+        if st.button("Apply Refinement"):
+            refine_instructions = (
+                f"Rewrite in a {tone.lower()} tone. " if tone != "Default" else ""
+            )
+            refine_instructions += instructions
+            target_key = (
+                "concise_text" if version_to_refine == "Concise" else "detailed_text"
+            )
+            if refine_instructions.strip():
+                st.session_state[target_key] = llm.refine_cover_letter(
+                    st.session_state[target_key], refine_instructions
+                )
+            else:
+                st.warning(
+                    "Please provide refinement instructions or select a tone."
+                )
+
+        final_choice = st.radio(
+            "Select final version", ["Concise", "Detailed"], key="final_choice"
+        )
+        if st.button("Finalize Cover Letter"):
+            final_letter = (
+                st.session_state.concise_text
+                if final_choice == "Concise"
+                else st.session_state.detailed_text
+            )
+            st.session_state["final_letter"] = final_letter
+        if st.session_state.get("final_letter"):
+            st.subheader("Final Cover Letter")
+            st.code(st.session_state.final_letter, language="markdown")
+
+        st.subheader("Skill Match Analysis")
+        st.metric("Overall Score", f"{st.session_state.score * 100:.1f}%")
+        if st.session_state.breakdown:
+            chart_df = pd.DataFrame(
+                {
+                    "Skill": list(st.session_state.breakdown.keys()),
+                    "Relevance": [
+                        v * 100 for v in st.session_state.breakdown.values()
+                    ],
+                }
+            ).set_index("Skill")
+            st.bar_chart(chart_df)
+
+        if st.session_state.skill_map["matched"]:
+            st.info(
+                "Matched skills: " + ", ".join(st.session_state.skill_map["matched"])
+            )
+        if st.session_state.skill_map["gaps"]:
+            st.warning(
+                "Skill gaps: " + ", ".join(st.session_state.skill_map["gaps"])
+            )
+
+    if st.session_state.get("qa_generated"):
+        st.subheader("Interview Q&A")
+        st.code(st.session_state.qa_pairs, language="markdown")
 
 
 if __name__ == "__main__":
     chain = Chain()
     st.set_page_config(
-        layout="wide", page_title="Cover Letter and Interview Q&A Generator", page_icon="📄"
+        layout="wide",
+        page_title="Cover Letter and Interview Q&A Generator",
+        page_icon="📄",
     )
     create_streamlit_app(chain, clean_text)
 

--- a/app/main.py
+++ b/app/main.py
@@ -90,16 +90,20 @@ def create_streamlit_app(llm: Chain, clean_text_fn):
             st.text_area("Detailed Cover Letter", key="detailed_text", height=300)
 
         st.subheader("Refine Cover Letter")
-        version_to_refine = st.selectbox(
+        st.selectbox(
             "Version to refine", ["Concise", "Detailed"], key="version_select"
         )
-        tone = st.selectbox(
+        st.selectbox(
             "Tone", ["Default", "Formal", "Friendly", "Confident"], key="tone_select"
         )
-        instructions = st.text_input(
+        st.text_input(
             "Additional instructions (optional)", key="refine_instruction"
         )
-        if st.button("Apply Refinement"):
+
+        def apply_refinement():
+            version_to_refine = st.session_state.version_select
+            tone = st.session_state.tone_select
+            instructions = st.session_state.refine_instruction
             refine_instructions = (
                 f"Rewrite in a {tone.lower()} tone. " if tone != "Default" else ""
             )
@@ -111,21 +115,22 @@ def create_streamlit_app(llm: Chain, clean_text_fn):
                 st.session_state[target_key] = llm.refine_cover_letter(
                     st.session_state[target_key], refine_instructions
                 )
-            else:
-                st.warning(
-                    "Please provide refinement instructions or select a tone."
-                )
+
+        st.button("Apply Refinement", on_click=apply_refinement)
 
         final_choice = st.radio(
             "Select final version", ["Concise", "Detailed"], key="final_choice"
         )
-        if st.button("Finalize Cover Letter"):
-            final_letter = (
+
+        def finalize_cover_letter():
+            choice = st.session_state.final_choice
+            st.session_state["final_letter"] = (
                 st.session_state.concise_text
-                if final_choice == "Concise"
+                if choice == "Concise"
                 else st.session_state.detailed_text
             )
-            st.session_state["final_letter"] = final_letter
+
+        st.button("Finalize Cover Letter", on_click=finalize_cover_letter)
         if st.session_state.get("final_letter"):
             st.subheader("Final Cover Letter")
             st.code(st.session_state.final_letter, language="markdown")

--- a/app/main.py
+++ b/app/main.py
@@ -14,12 +14,18 @@ from utils import (
 
 
 def create_streamlit_app(llm: Chain, clean_text_fn):
-    st.title("📄 Cover Letter Generator")
+    st.title("📄 Cover Letter and Interview Q&A Generator")
 
     resume_file = st.file_uploader("Upload your resume (PDF)", type=["pdf"])
     job_input = st.text_area("Job Description or URL")
 
-    if st.button("Generate Cover Letter"):
+    col1, col2 = st.columns(2)
+    with col1:
+        generate_cover_letter = st.button("Generate Cover Letter")
+    with col2:
+        generate_qa = st.button("Generate Interview Q&A")
+
+    if generate_cover_letter or generate_qa:
         if not resume_file or not job_input:
             st.error("Please provide both a resume and a job description or URL.")
             return
@@ -31,26 +37,99 @@ def create_streamlit_app(llm: Chain, clean_text_fn):
             resume_info = extract_structured_info(resume_text)
             job_description = load_job_description(job_input)
 
-            job_skills = extract_job_skills(job_description)
-            skill_map = map_skills(resume_info["skills"], job_skills)
-            score, breakdown = compute_skill_match_score(resume_text, job_skills)
+            if generate_cover_letter:
+                job_skills = extract_job_skills(job_description)
+                skill_map = map_skills(resume_info["skills"], job_skills)
+                score, breakdown = compute_skill_match_score(resume_text, job_skills)
+                concise_letter = llm.write_cover_letter(
+                    resume_info, job_description, style="concise"
+                )
+                detailed_letter = llm.write_cover_letter(
+                    resume_info, job_description, style="detailed"
+                )
 
-            cover_letter = llm.write_cover_letter(resume_info, job_description)
-            st.code(cover_letter, language="markdown")
+                if "concise_text" not in st.session_state:
+                    st.session_state.concise_text = concise_letter
+                if "detailed_text" not in st.session_state:
+                    st.session_state.detailed_text = detailed_letter
 
-            st.subheader("Skill Match Analysis")
-            st.metric("Overall Score", f"{score * 100:.1f}%")
-            if breakdown:
-                chart_df = pd.DataFrame({
-                    "Skill": list(breakdown.keys()),
-                    "Relevance": [v * 100 for v in breakdown.values()],
-                }).set_index("Skill")
-                st.bar_chart(chart_df)
+                st.subheader("Cover Letter Versions")
+                col_a, col_b = st.columns(2)
+                with col_a:
+                    st.subheader("Concise")
+                    st.text_area(
+                        "Concise Cover Letter",
+                        key="concise_text",
+                        height=300,
+                    )
+                with col_b:
+                    st.subheader("Detailed")
+                    st.text_area(
+                        "Detailed Cover Letter",
+                        key="detailed_text",
+                        height=300,
+                    )
 
-            if skill_map["matched"]:
-                st.info("Matched skills: " + ", ".join(skill_map["matched"]))
-            if skill_map["gaps"]:
-                st.warning("Skill gaps: " + ", ".join(skill_map["gaps"]))
+                st.subheader("Refine Cover Letter")
+                version_to_refine = st.selectbox(
+                    "Version to refine", ["Concise", "Detailed"], key="version_select"
+                )
+                tone = st.selectbox(
+                    "Tone",
+                    ["Default", "Formal", "Friendly", "Confident"],
+                    key="tone_select",
+                )
+                instructions = st.text_input(
+                    "Additional instructions (optional)", key="refine_instruction"
+                )
+                if st.button("Apply Refinement"):
+                    refine_instructions = (
+                        f"Rewrite in a {tone.lower()} tone. " if tone != "Default" else ""
+                    )
+                    refine_instructions += instructions
+                    target_key = (
+                        "concise_text" if version_to_refine == "Concise" else "detailed_text"
+                    )
+                    if refine_instructions.strip():
+                        st.session_state[target_key] = llm.refine_cover_letter(
+                            st.session_state[target_key], refine_instructions
+                        )
+                    else:
+                        st.warning(
+                            "Please provide refinement instructions or select a tone."
+                        )
+
+                final_choice = st.radio(
+                    "Select final version", ["Concise", "Detailed"], key="final_choice"
+                )
+                if st.button("Finalize Cover Letter"):
+                    final_letter = (
+                        st.session_state.concise_text
+                        if final_choice == "Concise"
+                        else st.session_state.detailed_text
+                    )
+                    st.subheader("Final Cover Letter")
+                    st.code(final_letter, language="markdown")
+
+                st.subheader("Skill Match Analysis")
+                st.metric("Overall Score", f"{score * 100:.1f}%")
+                if breakdown:
+                    chart_df = pd.DataFrame(
+                        {
+                            "Skill": list(breakdown.keys()),
+                            "Relevance": [v * 100 for v in breakdown.values()],
+                        }
+                    ).set_index("Skill")
+                    st.bar_chart(chart_df)
+
+                if skill_map["matched"]:
+                    st.info("Matched skills: " + ", ".join(skill_map["matched"]))
+                if skill_map["gaps"]:
+                    st.warning("Skill gaps: " + ", ".join(skill_map["gaps"]))
+
+            else:
+                qa_pairs = llm.generate_interview_qa(resume_info, job_description)
+                st.code(qa_pairs, language="markdown")
 
         except Exception as e:
             st.error(f"An Error Occurred: {e}")
@@ -58,6 +137,8 @@ def create_streamlit_app(llm: Chain, clean_text_fn):
 
 if __name__ == "__main__":
     chain = Chain()
-    st.set_page_config(layout="wide", page_title="Cover Letter Generator", page_icon="📄")
+    st.set_page_config(
+        layout="wide", page_title="Cover Letter and Interview Q&A Generator", page_icon="📄"
+    )
     create_streamlit_app(chain, clean_text)
 


### PR DESCRIPTION
## Summary
- extend Chain with `generate_interview_qa` to create interview questions and answers from resume and job description
- update Streamlit UI with button to generate interview Q&A alongside cover letter
- allow interactive cover letter editing with tone adjustments, refinement instructions, and side-by-side concise and detailed versions

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`
